### PR TITLE
Fix bug with customer default params

### DIFF
--- a/data/resources/2014-11-05/customer.js
+++ b/data/resources/2014-11-05/customer.js
@@ -3,9 +3,9 @@ var assign = require('assign-deep')
 module.exports = function mockCustomer (params) {
   params = params || {}
   params.id = params.id || "cus_00000000000000"
-  params.cards = params.cards || {}
+  params.cards = params.cards || { data: [] }
   params.cards.total_count = params.cards.data.length
-  params.subscriptions = params.subscriptions || {}
+  params.subscriptions = params.subscriptions || { data: [] }
   params.subscriptions.total_count = params.subscriptions.data.length
 
   return assign({


### PR DESCRIPTION
Default `customer.card.data` and `customer.subscriptions.data` to `[]` (or else it breaks on `params.cards.data.length` and `params.subscriptions.data.length`).
